### PR TITLE
[ADD] 채팅방 메시지 국적별 자동 번역

### DIFF
--- a/KODI/src/main/java/config/NaverInfo.java
+++ b/KODI/src/main/java/config/NaverInfo.java
@@ -1,0 +1,7 @@
+package config;
+
+public class NaverInfo {
+	// papago 서비스 인증정보
+	public static final String papago_clientId = "2pqjavoj7f";
+	public static final String papago_clientSecret = "n9P36P71pQ9Tu34HryElFnekrDnvrAbeyHVl2XZ7";	
+}

--- a/KODI/src/main/java/config/WebSocketHandler.java
+++ b/KODI/src/main/java/config/WebSocketHandler.java
@@ -18,9 +18,11 @@ public class WebSocketHandler extends TextWebSocketHandler {
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
 		System.out.println(session.getRemoteAddress() + " 에서 접속했습니다."); // 클라이언트 IP
-		if(list.size() < 1) { // 일단 현재 사용자가 채팅방 하나만 열 수 있도록 제한
+		// 브라우저 여는 것마다 다 통신해서 일단 현재 사용자가 채팅방 하나만 열 수 있도록 제한
+		if(list.size() < 1) {
 			list.add(session);
 		}
+		//list.add(session);
 	}
 
 	@Override

--- a/KODI/src/main/java/controller/DiningCostController.java
+++ b/KODI/src/main/java/controller/DiningCostController.java
@@ -9,32 +9,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
 
 import dto.DiningCostDTO;
 import service.DiningCostService;
 
-//@RestController
 @Controller
 @RequestMapping("/api")
 public class DiningCostController {
 	@Autowired
 	@Qualifier("diningcostservice")
 	DiningCostService service;
-	
-	/**
-	 * 백엔드 테스트
-	 * @return
-	 */
-	@GetMapping("/test")
-	public List<DiningCostDTO> selectAllTest(){
-		return service.selectAllCost();
-	}
-	@PostMapping("/test")
-	public DiningCostDTO selectOneTest(String item) {
-		return service.selectOneCost(item);
-	}
 	
 	/**
 	 * 전체 품목 외식비 정보 API (default)
@@ -56,11 +41,10 @@ public class DiningCostController {
 	 * @param item
 	 * @return 특정 품목 외식비
 	 */
-	@PostMapping("/diningcost")
+	@PostMapping("/diningcost/one")
 	@ResponseBody
 	public DiningCostDTO selectOneCost(String item) {
 		return service.selectOneCost(item);
 	}
-	
 	
 }

--- a/KODI/src/main/java/dao/LiveChatDAO.java
+++ b/KODI/src/main/java/dao/LiveChatDAO.java
@@ -41,4 +41,10 @@ public interface LiveChatDAO {
 	 */
 	int insertChatMsg(HashMap<String, Object> map);
 
+	/**
+	 * 국적 조회
+	 * @param memberIdx
+	 */
+	String selectCountry(int memberIdx);
+
 }

--- a/KODI/src/main/java/service/PapagoService.java
+++ b/KODI/src/main/java/service/PapagoService.java
@@ -1,0 +1,209 @@
+package service;
+
+//네이버 Papago Text Translation API 예제
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import config.NaverInfo;
+import dao.LiveChatDAO;
+
+@Service("papagoservice")
+public class PapagoService{
+	
+	@Autowired
+	@Qualifier("livechatdao")
+	LiveChatDAO dao;
+	
+	/**
+	 * 메시지 보낸 사람과 현재 사용자의 국적 비교
+	 * @param memberIdx
+	 * @param msgMemberIdx
+	 * @return 국적이 같은지(false) 다른지(true) 여부
+	 */
+	public boolean compareLang(int memberIdx, int msgMemberIdx) {
+		String srcLangType; // 메시지 보낸 친구 국적
+		String tarLangType; // 내 국적
+		
+		String friendCountry = dao.selectCountry(msgMemberIdx);
+		String myCountry = dao.selectCountry(memberIdx);
+		
+		if(friendCountry.equals("South Korea")) {
+			srcLangType = "ko";
+		} else if (friendCountry.equals("Japan")) {
+			srcLangType = "ja";
+		} else if (friendCountry.equals("China")) {
+			srcLangType = "zh-TW";
+		} else if (friendCountry.equals("Vietnam")) {
+			srcLangType = "vi";
+		} else if (friendCountry.equals("Thailand")) {
+			srcLangType = "th";
+		} else if (friendCountry.equals("Indonesia")) {
+			srcLangType = "id";
+		} else if (friendCountry.equals("France")) {
+			srcLangType = "fr";
+		} else if (friendCountry.equals("Spain")) {
+			srcLangType = "es";
+		} else if (friendCountry.equals("Russia")) {
+			srcLangType = "ru";
+		} else if (friendCountry.equals("Germany")) {
+			srcLangType = "de";
+		} else if (friendCountry.equals("Italy")) {
+			srcLangType = "it";
+		} else {
+			srcLangType = "en";
+		}
+		
+		if(myCountry.equals("South Korea")) {
+			tarLangType = "ko";
+		} else if (myCountry.equals("Japan")) {
+			tarLangType = "ja";
+		} else if (myCountry.equals("China")) {
+			tarLangType = "zh-TW";
+		} else if (myCountry.equals("Vietnam")) {
+			tarLangType = "vi";
+		} else if (myCountry.equals("Thailand")) {
+			tarLangType = "th";
+		} else if (myCountry.equals("Indonesia")) {
+			tarLangType = "id";
+		} else if (myCountry.equals("France")) {
+			tarLangType = "fr";
+		} else if (myCountry.equals("Spain")) {
+			tarLangType = "es";
+		} else if (myCountry.equals("Russia")) {
+			tarLangType = "ru";
+		} else if (myCountry.equals("Germany")) {
+			tarLangType = "de";
+		} else if (myCountry.equals("Italy")) {
+			tarLangType = "it";
+		} else {
+			tarLangType = "en";
+		}
+		
+		if(srcLangType == tarLangType) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+	
+
+	/**
+	 * 채팅방 메시지 국적에 따라 번역
+	 * @param text
+	 * @return 번역한 내용
+	 */
+	public String translateMsg(int memberIdx, int msgMemberIdx, String text) {
+		String result = "";
+		
+		String clientId = NaverInfo.papago_clientId;
+		String clientSecret = NaverInfo.papago_clientSecret;
+		
+		try {
+			// request
+			text = URLEncoder.encode(text, "UTF-8");
+			String apiURL = "https://naveropenapi.apigw.ntruss.com/nmt/v1/translation";
+			URL url = new URL(apiURL);
+			HttpURLConnection con = (HttpURLConnection) url.openConnection();
+			con.setRequestMethod("POST");
+			con.setRequestProperty("X-NCP-APIGW-API-KEY-ID", clientId);
+			con.setRequestProperty("X-NCP-APIGW-API-KEY", clientSecret);
+			
+			// post request
+			String srcLangType; // 메시지 보낸 친구 국적
+			String tarLangType; // 내 국적
+			
+			String friendCountry = dao.selectCountry(msgMemberIdx);
+			String myCountry = dao.selectCountry(memberIdx);
+			
+			if(friendCountry.equals("South Korea")) {
+				srcLangType = "ko";
+			} else if (friendCountry.equals("Japan")) {
+				srcLangType = "ja";
+			} else if (friendCountry.equals("China")) {
+				srcLangType = "zh-TW";
+			} else if (friendCountry.equals("Vietnam")) {
+				srcLangType = "vi";
+			} else if (friendCountry.equals("Thailand")) {
+				srcLangType = "th";
+			} else if (friendCountry.equals("Indonesia")) {
+				srcLangType = "id";
+			} else if (friendCountry.equals("France")) {
+				srcLangType = "fr";
+			} else if (friendCountry.equals("Spain")) {
+				srcLangType = "es";
+			} else if (friendCountry.equals("Russia")) {
+				srcLangType = "ru";
+			} else if (friendCountry.equals("Germany")) {
+				srcLangType = "de";
+			} else if (friendCountry.equals("Italy")) {
+				srcLangType = "it";
+			} else {
+				srcLangType = "en";
+			}
+			
+			if(myCountry.equals("South Korea")) {
+				tarLangType = "ko";
+			} else if (myCountry.equals("Japan")) {
+				tarLangType = "ja";
+			} else if (myCountry.equals("China")) {
+				tarLangType = "zh-TW";
+			} else if (myCountry.equals("Vietnam")) {
+				tarLangType = "vi";
+			} else if (myCountry.equals("Thailand")) {
+				tarLangType = "th";
+			} else if (myCountry.equals("Indonesia")) {
+				tarLangType = "id";
+			} else if (myCountry.equals("France")) {
+				tarLangType = "fr";
+			} else if (myCountry.equals("Spain")) {
+				tarLangType = "es";
+			} else if (myCountry.equals("Russia")) {
+				tarLangType = "ru";
+			} else if (myCountry.equals("Germany")) {
+				tarLangType = "de";
+			} else if (myCountry.equals("Italy")) {
+				tarLangType = "it";
+			} else {
+				tarLangType = "en";
+			}
+			
+			String postParams = "source="+srcLangType+"&target="+tarLangType+"&text=" + text;
+			con.setDoOutput(true);
+			DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+			wr.writeBytes(postParams);
+			wr.flush();
+			wr.close();
+			
+			// response
+			int responseCode = con.getResponseCode();
+			BufferedReader br;
+			if (responseCode == 200) {
+				br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+			} else {
+				br = new BufferedReader(new InputStreamReader(con.getErrorStream()));
+			}
+			String inputLine;
+			StringBuffer response = new StringBuffer();
+			while ((inputLine = br.readLine()) != null) {
+				response.append(inputLine);
+			}
+			br.close();
+			System.out.println(response.toString());
+			
+			result = response.toString();
+		} catch (Exception e) {
+			System.out.println(e);
+		}
+		
+		return result;
+	}
+
+}

--- a/KODI/src/main/resources/mybatis/mapper/LiveChat-mapping.xml
+++ b/KODI/src/main/resources/mybatis/mapper/LiveChat-mapping.xml
@@ -9,10 +9,13 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		select chat_msg_idx as chatMsgIdx, content, regdate, member_idx as memberIdx, chat_idx as chatIdx from chat_msg where chat_idx = #{chatIdx}
 	</select>
 	<select id="verifyMember" resultType="int" parameterType="hashmap">
-		select count(*) from chat where chat_idx = #{chatIdx} and (member1_idx = #{memberIdx} or member2_idx = #{memberIdx});
+		select count(*) from chat where chat_idx = #{chatIdx} and (member1_idx = #{memberIdx} or member2_idx = #{memberIdx})
 	</select>
 	<select id="selectMemberName" resultType="String" parameterType="int">
 		select member_name as memberName from members where member_idx = #{memberIdx}
+	</select>
+	<select id="selectCountry" resultType="String" parameterType="int">
+		select country from flag where flag_idx = (select flag_idx from members where member_idx = #{memberIdx})
 	</select>
 	
 	<!-- insert -->

--- a/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
@@ -111,7 +111,7 @@
 				if(searchInput.value == ""){
 					alert("검색할 친구를 입력해주세요");
 				} else {
-					var data = {memberIdx: 31, friendName: searchInput.value};
+					var data = {memberIdx: 1, friendName: searchInput.value};
 					
 					$.ajax({
 						url: "/api/chatlist/search",

--- a/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
@@ -111,7 +111,7 @@
 				if(searchInput.value == ""){
 					alert("검색할 친구를 입력해주세요");
 				} else {
-					var data = {memberIdx: 1, friendName: searchInput.value};
+					var data = {memberIdx: 31, friendName: searchInput.value};
 					
 					$.ajax({
 						url: "/api/chatlist/search",

--- a/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
@@ -54,6 +54,7 @@
 		let friendName;
 		let content;
 		let regdate;
+		let json;
 		
 		<c:forEach items="${allChatMsg}" var="one">
 			oneMsg = document.createElement("div");
@@ -65,8 +66,11 @@
 			
 			content = document.createElement("p");
 			content.setAttribute("id", "content");
-			content.innerHTML = "${one.chatMsgDTO.content}";
-
+			
+			json = JSON.parse('${one.chatMsgDTO.content}');
+			
+			content.innerHTML = json.message.result.translatedText;
+			
 			regdate = document.createElement("p");
 			regdate.setAttribute("id", "regdate");
 			regdate.innerHTML = "${one.chatMsgDTO.regdate}";


### PR DESCRIPTION
- diningCost 품목별 가격 조회 API 수정
- 채팅 자동 번역 기능
  - NCP, Papago translation API 사용
  - 메시지 보낸 사람과 현재 세션에 해당하는 사용자의 memberIdx를 통해 국적을 비교하여 같으면 번역하지 않고 다르면 자동 번역
  - 번역 가능 언어: 한국어, 영어, 일본어, 중국어 번체, 베트남어, 태국어, 인도네시아어, 프랑스어, 스페인어, 러시아어, 독일어, 이탈리아어
    - 참고: https://api.ncloud-docs.com/docs/ai-naver-papagonmt-translation
- 실시간 채팅방
  - 현재 켜져있는 브라우저끼리 다 통신해서 통신할 수 있는 브라우저 1개로 제한 (추후 보완)