### PR TITLE
[UPDATE] 실시간 채팅 기능 & 게시글 상세 페이지 댓글 권한 수정

### DIFF
--- a/KODI/src/main/java/config/WebSocketHandler.java
+++ b/KODI/src/main/java/config/WebSocketHandler.java
@@ -24,9 +24,10 @@ public class WebSocketHandler extends TextWebSocketHandler {
 			homeList.add(session);
 		} else {
 			// 브라우저 여는 것마다 다 통신해서 일단 현재 사용자가 채팅방 하나만 열 수 있도록 제한
-			if(chatList.size() < 1) {
-				chatList.add(session);
-			}	
+			/*
+			 * if(chatList.size() < 1) { chatList.add(session); }
+			 */
+			chatList.add(session);
 		}
 	}
 

--- a/KODI/src/main/java/controller/LiveChatController.java
+++ b/KODI/src/main/java/controller/LiveChatController.java
@@ -100,4 +100,26 @@ public class LiveChatController {
 		return liveChatService.showMemberName(memberIdx);
 	}
 	
+	/**
+	 * 실시간 통신하는 메시지 자동번역
+	 * @param session
+	 * @param msg
+	 * @param sendMemberIdx
+	 * @return 국적별로 자동번역한 메시지 내용
+	 */
+	@PostMapping("/chatroom/translatemsg")
+	@ResponseBody
+	public String translateMsg(HttpSession session, String msg, int sendMemberIdx) {
+		int memberIdx = Integer.parseInt(String.valueOf(session.getAttribute("memberIdx")));
+		
+		boolean compareLang = papagoService.compareLang(memberIdx, sendMemberIdx);
+		String content;
+		
+		if(compareLang == false) { // 같은 언어를 쓰는 사람들이면 메시지 그대로 전달
+			content = "{\"message\":{\"result\":{\"srcLangType\":\"ko\",\"tarLangType\":\"ko\",\"translatedText\":\""+ msg +"\"}}}";
+		} else { // 다른 언어를 쓰면 번역해서 전달
+			content = papagoService.translateMsg(memberIdx, sendMemberIdx, msg);
+		}
+		return content;
+	}
 }

--- a/KODI/src/main/resources/static/css/ReadPostOne.css
+++ b/KODI/src/main/resources/static/css/ReadPostOne.css
@@ -177,7 +177,7 @@
 	margin-top: 40px;
 	margin-bottom: 30px;
 	padding-top: 20px;
-	padding-bottom: 30px;
+	padding-bottom: 15px;
 	padding-left: 30px;
 	padding-right: 30px;
 	border-radius: 10px;

--- a/KODI/src/main/webapp/WEB-INF/views/Home.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Home.jsp
@@ -41,8 +41,8 @@
 			websocket = null;
 
 			if(websocket == null){
-/* 				websocket = new WebSocket("ws://localhost:7777/home");
- */				websocket = new WebSocket("ws://192.168.0.13:7777/home");
+				//websocket = new WebSocket("ws://localhost:7777/home");
+				websocket = new WebSocket("ws://192.168.0.13:7777/home");
 				
 				websocket.onopen = function(){console.log("웹소켓 연결성공");};
 				websocket.onclose = function(){console.log("웹소켓 해제성공");};

--- a/KODI/src/main/webapp/WEB-INF/views/Home.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Home.jsp
@@ -41,13 +41,16 @@
 			websocket = null;
 
 			if(websocket == null){
-				websocket = new WebSocket("ws://localhost:7777/home");
+/* 				websocket = new WebSocket("ws://localhost:7777/home");
+ */				websocket = new WebSocket("ws://192.168.0.13:7777/home");
 				
 				websocket.onopen = function(){console.log("웹소켓 연결성공");};
 				websocket.onclose = function(){console.log("웹소켓 해제성공");};
 				websocket.onmessage = function(event){ // 서버로부터 데이터 받는 부분
 					console.log("웹소켓 서버로부터 수신성공");
 					
+					let sendInfo = event.data.split(",");
+										
 					var nowDate = new Date();
 					
 					var year = nowDate.getFullYear();
@@ -70,7 +73,7 @@
 					
 					$.ajax({
 						url: "/api/chatroom/showmembername",
-						data: {"memberIdx": sessionId},
+						data: {"memberIdx": sendInfo[1]},
 						type: "post",
 						dataType: "text",
 						success: function(response){
@@ -82,7 +85,7 @@
 							
 							content = document.createElement("p");
 							content.setAttribute("id", "content");
-							content.innerHTML = event.data;
+							content.innerHTML = sendInfo[0];
 
 							regdate = document.createElement("p");
 							regdate.setAttribute("id", "regdate");
@@ -110,11 +113,12 @@
 				if(sendMsgInput.value == ""){
 					$("#sendMsgBtn").attr("disabled", false);
 				} else {
-					let msg = sendMsgInput.value;			
-					websocket.send(msg);
+					let sendData = [sendMsgInput.value, sessionId];
+					websocket.send(sendData);
+
 					sendMsgInput.value = "";
 					console.log("웹소켓 서버에게 송신성공");
-				};			
+				};
 			});
 		};
 	</script>

--- a/KODI/src/main/webapp/WEB-INF/views/ReadPostOne.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ReadPostOne.jsp
@@ -167,7 +167,7 @@
 		
 		// 기존 데이터베이스에 있는 댓글 먼저 정렬
 		if(${readPostOne.comments.size() > 0}){
-			<c:forEach items="${readPostOne.comments}" var="one">            
+			<c:forEach items="${readPostOne.comments}" var="one">
 				comment = document.createElement("span");
 				comment.setAttribute("id", `${one.memberIdx}`);
 				
@@ -188,7 +188,7 @@
 				deleteBtn.setAttribute("id", "deleteBtn");
 				deleteBtn.setAttribute("value", "삭제");
 				deleteBtn.setAttribute("style", "display: inline; border:none; background-color:#EDF2F6; color:grey; float:right;");
-				deleteBtn.setAttribute("onclick", `deleteCommentBtn(${one.commentIdx})`);
+				deleteBtn.setAttribute("onclick", `deleteCommentBtn(${one.commentIdx}, ${one.memberIdx})`);
 								
 				comment.appendChild(commentMemberName);
 				comment.appendChild(commentText);
@@ -243,8 +243,8 @@
 		});
 	};
 	
-	function deleteCommentBtn(commentIdx) {
-		if(sessionId == ${readPostOne.postInfo.memberIdx}){
+	function deleteCommentBtn(commentIdx, memberIdx) {
+		if(sessionId == ${readPostOne.postInfo.memberIdx} || sessionId == memberIdx){
 			let isDelete = confirm("해당 댓글을 삭제하시겠습니까?");
 			
 			if (isDelete){
@@ -350,15 +350,8 @@
 				<p>게시글 내용</p>
 			</div>
 
-			<div id="addrDiv">
-				주소
-				<p id="addrInfo">서울시 강남구</p>
-			</div>
-
-			<div id="tagDiv">
-				태그
-				<!-- <div id="tag1">예시</div> -->
-			</div>
+			<div id="addrDiv"> 주소 <p id="addrInfo"></p> </div>
+			<div id="tagDiv"> 태그 </div>
 		</div>
 
 		<!-- 좋아요, 마킹, 공유 -->


### PR DESCRIPTION
- 홈페이지 & 실시간 채팅방
  - 문제점: 실시간 통신할 때 채팅 사용자 이름 출력 시, session 값을 넘겨줘서 다른 사람이 보낸 메시지 이름도 현재 사용자 이름으로 출력
  - 해결: 송신 쪽에서 메시지를 보낼 때 해당 송신자의 sessionId 값도 배열로 같이 담아 수신 쪽에서 사용
- 실시간 채팅방
  - 문제점: 데이터베이스에 있는 과거 채팅 내역을 조회해올 때는 회원의 국적에 따라 자동번역 해서 출력해주는데 실시간 통신할 때는 자동 번역을 안하고 송신자의 메시지를 수신자 측에서도 그대로 전달
  - 해결: 실시간 통신할 때도 자동 번역 API를 추가해서 회원의 국적에 따라 번역해서 출력
- 게시글 상세 페이지
  - 문제점: 댓글 삭제 권한이 해당 게시글 작성자에게만 있고 해당 댓글 작성자는 삭제 불가능
  - 해결: 댓글 삭제 권한을 해당 게시글 작성자와 해당 댓글 작성자에게 부여