### PR TITLE
[UPDATE] 실시간 채팅 페이지 완성

### DIFF
--- a/KODI/src/main/java/config/WebSocketConfig.java
+++ b/KODI/src/main/java/config/WebSocketConfig.java
@@ -17,7 +17,7 @@ public class WebSocketConfig implements WebSocketConfigurer{
 	
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-		registry.addHandler(webSocketHandler, "/ws").setAllowedOrigins("*");
+		registry.addHandler(webSocketHandler, "/chatroom").setAllowedOrigins("*");
 		registry.addHandler(webSocketHandler, "/home").setAllowedOrigins("*");
 	}
 }

--- a/KODI/src/main/java/config/WebSocketHandler.java
+++ b/KODI/src/main/java/config/WebSocketHandler.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketMessage;
@@ -13,51 +15,102 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 @Component
 public class WebSocketHandler extends TextWebSocketHandler {
 
-	List<WebSocketSession> homeList = new ArrayList<WebSocketSession>(); // 한 채팅방에 모여 있는 클라이언트 리스트
-	List<WebSocketSession> chatList = new ArrayList<WebSocketSession>(); // 한 채팅방에 모여 있는 클라이언트 리스트
+	List<WebSocketSession> homeList = new ArrayList<WebSocketSession>(); // 한 채팅방에 모여 있는 클라이언트 리스트	
+	MultiValueMap<Integer, WebSocketSession> chatListByChatIdx = new LinkedMultiValueMap<>(); // 채팅방 번호와 웹소켓 세션 저장
 	
+	int chatIdx;
+
+	/**
+	 * 웹소켓 연결
+	 */
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
 		System.out.println(session.getRemoteAddress() + " 에서 접속했습니다."); // 클라이언트 IP
-				
+		
 		if(session.getUri().getPath().equals("/home")) {
 			homeList.add(session);
-		} else {
-			// 브라우저 여는 것마다 다 통신해서 일단 현재 사용자가 채팅방 하나만 열 수 있도록 제한
-			/*
-			 * if(chatList.size() < 1) { chatList.add(session); }
-			 */
-			chatList.add(session);
 		}
 	}
-
+	
+	/**
+	 * 웹소켓 메시지 전송
+	 * 웹소켓 연결되어있는 클라이언트(session)가 메시지(message)를 보낼 때 자동 실행
+	 * 나머지 클라이언트(list에 저장)에게 해당 메시지를 전송해주는 기능 구현
+	 */
 	@Override
 	public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
-		// 웹소켓 연결되어있는 클라이언트(session)가 메시지(message)를 보낼 때 자동 실행
-		// 나머지 클라이언트(list에 저장)에게 해당 메시지를 전송해주는 기능 구현
-		String msg = (String) message.getPayload(); // 전송받은 메시지만 뽑아내는 함수
+		String msg = (String) message.getPayload(); // 전송받은 메시지
 		
 		if(session.getUri().getPath().equals("/home")) {
 			for (WebSocketSession socket : homeList) {
 				WebSocketMessage<String> sendmsg = new TextMessage(msg);
 				socket.sendMessage(sendmsg);
 			}
-		} else {
-			for (WebSocketSession socket : chatList) {
-				WebSocketMessage<String> sendmsg = new TextMessage(msg);
-				socket.sendMessage(sendmsg);
+		} else {		
+			// 웹소켓 시작과 종료 시 데이터: 채팅방 번호(chatIdx)
+			if(message.getPayload().toString().contains(",") == false) {
+				chatIdx = Integer.parseInt(message.getPayload().toString());
+				
+				if(chatListByChatIdx.get(chatIdx) == null || chatListByChatIdx.get(chatIdx).isEmpty()) {
+					chatListByChatIdx.add(chatIdx, session);
+				} else {
+					List<WebSocketSession> socketList = chatListByChatIdx.get(chatIdx);
+
+					System.out.println("저장 sessionId: " + session.getId());
+					System.out.println("저장 전 socketList: " + socketList);
+
+					for (int i = 0; i < socketList.size(); i++) {
+						if(socketList.get(i).getId() == session.getId()) {
+							chatListByChatIdx.get(chatIdx).remove(i);
+							break;
+						}
+					}
+					
+					chatListByChatIdx.add(chatIdx, session);
+					
+					System.out.println("저장 후 socketList: " + socketList);
+				}
+				
+				System.out.println("chatListByChatIdx: " + chatListByChatIdx);
+			} else { // 메시지 전송 시 데이터: 메시지 내용(sendMsg), 회원 번호(sessionId), 채팅방 번호(chatIdx)
+				chatIdx = Integer.parseInt(message.getPayload().toString().split(",")[2]);
+				
+				List<WebSocketSession> sessionList = chatListByChatIdx.get(chatIdx);
+
+				System.out.println("sendMsg sessionList: "+ sessionList);
+			
+				for (WebSocketSession webSocketSession : sessionList) {
+					System.out.println("sendMsg webSocketSession: "+webSocketSession);
+				}
+				
+				for (WebSocketSession socket : sessionList) {
+					WebSocketMessage<String> sendmsg = new TextMessage(msg);
+					socket.sendMessage(sendmsg);
+				}
 			}
 		}
 	}
 
+	/**
+	 * 웹소켓 종료
+	 */
 	@Override
 	public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
 		System.out.println(session.getRemoteAddress() + " 에서 해제했습니다.");
+
 		if(session.getUri().getPath().equals("/home")) {
 			homeList.remove(session);			
-		} else {
-			chatList.remove(session);
+		} else {			
+			List<WebSocketSession> socket = chatListByChatIdx.get(chatIdx);
+			
+			for (int i = 0; i < socket.size(); i++) {				
+				if(socket.get(i) == session) {
+					System.out.println("종료 세션값: "+socket.get(i));
+					chatListByChatIdx.get(chatIdx).remove(i);
+				}
+			}
 		}
+		System.out.println("종료 후 map: "+chatListByChatIdx);
 	}
 
 }

--- a/KODI/src/main/java/controller/LiveChatController.java
+++ b/KODI/src/main/java/controller/LiveChatController.java
@@ -37,8 +37,16 @@ public class LiveChatController {
 	@GetMapping("/chatroom/{chatIdx}")
 	public ModelAndView liveChat(HttpSession session, @PathVariable int chatIdx) {
 		List<AllChatDTO> allChatMsg = liveChatService.selectAllChatMsg(chatIdx);
-		
-		int memberIdx = Integer.parseInt(String.valueOf(session.getAttribute("memberIdx")));
+
+		ModelAndView mv = new ModelAndView();
+		int memberIdx;
+
+		if(session.getAttribute("memberIdx") == null) {
+			mv.setViewName("redirect:/api/login");
+			return mv;
+		} else {
+			memberIdx = Integer.parseInt(String.valueOf(session.getAttribute("memberIdx")));			
+		}
 		
 		int n = 0;
 		
@@ -55,9 +63,7 @@ public class LiveChatController {
 			allChatMsg.get(n).getChatMsgDTO().setContent(msg);
 			n++;
 		}
-		
-		ModelAndView mv = new ModelAndView();
-		
+				
 		mv.addObject("allChatMsg", allChatMsg);
 		mv.addObject("chatIdx", chatIdx);
 		

--- a/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
@@ -83,13 +83,17 @@
 	};
 		
 	function webSocket(){
-		websocket = null;
+		let websocket = null;
 		
 		if(websocket == null){
-			//websocket = new WebSocket("ws://localhost:7777/ws");
-			websocket = new WebSocket("ws://192.168.0.13:7777/ws");
+			//websocket = new WebSocket("ws://localhost:7777/chatroom");
+			//websocket = new WebSocket("ws://192.168.0.13:7777/chatroom", "${chatIdx}");
+			websocket = new WebSocket("ws://192.168.0.13:7777/chatroom");
 			
-			websocket.onopen = function(){console.log("웹소켓 연결성공");};
+			websocket.onopen = function(){
+				console.log("웹소켓 연결성공");
+				websocket.send(${chatIdx});
+			};
 			websocket.onclose = function(){console.log("웹소켓 해제성공");};
 			websocket.onmessage = function(event){ // 서버로부터 데이터 받는 부분
 				console.log("웹소켓 서버로부터 수신성공");
@@ -172,7 +176,7 @@
 			if(sendMsgInput.value == ""){
 				$("#sendMsgBtn").attr("disabled", false);
 			} else {
-				let sendData = [sendMsgInput.value, sessionId];
+				let sendData = [sendMsgInput.value, sessionId, ${chatIdx}];
 				websocket.send(sendData);
 				
 				var data = {memberIdx: sessionId, chatIdx: ${chatIdx}, content: sendMsgInput.value};
@@ -196,6 +200,7 @@
 		});
 		
 		$("#exitChat").on("click", function(){
+			websocket.send(${chatIdx});
 			websocket.close();
 			location.href = "/api/chatlist/" + sessionId;
 		});

--- a/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
@@ -87,7 +87,6 @@
 		
 		if(websocket == null){
 			//websocket = new WebSocket("ws://localhost:7777/chatroom");
-			//websocket = new WebSocket("ws://192.168.0.13:7777/chatroom", "${chatIdx}");
 			websocket = new WebSocket("ws://192.168.0.13:7777/chatroom");
 			
 			websocket.onopen = function(){
@@ -155,7 +154,6 @@
 								oneMsg.innerHTML += "<hr>";
 								
 								allMsgList.appendChild(oneMsg);
-								//location.reload();
 							},
 							error: function(request, e){
 								alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);


### PR DESCRIPTION
- 문제점
  - 채팅방 번호 상관 없이 열려있는 브라우저마다 다 통신
-  해결
  - websocket 시작, 종료 시 채팅방 번호를 전송
  - websocket 시작, 종료 시 채팅방 번호만 전송하고 메시지 전송 시 메시지 내용, 채팅방 번호 등을 ,(콤마) 기준으로 전송
  - payload에 ,를 포함하지 않으면 websocket 시작, 종료 데이터이므로 session 값과 함께 map에 데이터 저장 및 삭제
  - payload에 ,를 포함면 메시지 전송 데이터이므로 해당 chatIdx를 key 값으로 가지고 있는 세션에만 메시지 전송