### PR TITLE
[UPDATE] 실시간 채팅 페이지, 홈페이지 수정

### DIFF
--- a/KODI/src/main/java/controller/HomeController.java
+++ b/KODI/src/main/java/controller/HomeController.java
@@ -6,11 +6,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
+import dto.HomeAllChatDTO;
 import dto.VehicleDTO;
+import jakarta.servlet.http.HttpSession;
 import service.HomeService;
+import service.PapagoService;
 
 @Controller
 @RequestMapping("/api")
@@ -19,22 +24,67 @@ public class HomeController {
 	@Qualifier("homeservice")
 	HomeService service;
 	
+	@Autowired
+	@Qualifier("papagoservice")
+	PapagoService papagoService;
+	
 	/**
 	 * 홈페이지 API
 	 * @return 교통수단 비용 리스트
 	 */
 	@GetMapping("/home")
-	public ModelAndView home() {
+	public ModelAndView home(HttpSession session) {
 		List<VehicleDTO> vehicleList = service.getVehicleList();
-
-		ModelAndView mv = new ModelAndView();
+		List<HomeAllChatDTO> allChatMsg = service.selectAllChatMsg();
 		
+		int memberIdx;
+		ModelAndView mv = new ModelAndView();
+
+		if(session.getAttribute("memberIdx") == null) {
+			mv.setViewName("redirect:/api/login");
+			return mv;
+		} else {
+			memberIdx = Integer.parseInt(String.valueOf(session.getAttribute("memberIdx")));			
+		}
+		
+		int n = 0;
+		
+		for (HomeAllChatDTO oneChat : allChatMsg) {	
+			boolean compareLang = papagoService.compareLang(memberIdx, oneChat.getChatMsgDTO().getMemberIdx());
+			String msg;
+			
+			if(compareLang == false) { // 같은 언어를 쓰는 사람들이면 메시지 그대로 전달
+				msg = "{\"message\":{\"result\":{\"srcLangType\":\"ko\",\"tarLangType\":\"ko\",\"translatedText\":\""+ oneChat.getChatMsgDTO().getContent() +"\"}}}";
+			} else { // 다른 언어를 쓰면 번역해서 전달
+				msg = papagoService.translateMsg(memberIdx, oneChat.getChatMsgDTO().getMemberIdx(), oneChat.getChatMsgDTO().getContent());
+			}
+						
+			allChatMsg.get(n).getChatMsgDTO().setContent(msg);
+			n++;
+		}
+				
+		mv.addObject("allChatMsg", allChatMsg);		
 		mv.addObject("vehicleList", vehicleList);
+		
 		mv.setViewName("Home");
 		
 		return mv;
 	}
 	
+	/**
+	 * WebSocket 메시지 DB 저장 및 삭제 API
+	 * @param chatMsgRq
+	 * @return DB 저장, 삭제 여부(1|0)
+	 */
+	@PostMapping("/home/savemsg")
+	@ResponseBody
+	public int saveMsg(int memberIdx, String content) {
+		System.out.println("controller: "+service.getChatMsgCnt());
+		if(service.getChatMsgCnt() >= 30) {
+			service.removeChatMsg();
+		}
+		return service.saveChatMsg(memberIdx, content);
+	}
 	
 	@GetMapping("/nonhome")
 	public ModelAndView nonhome() {

--- a/KODI/src/main/java/controller/HomeController.java
+++ b/KODI/src/main/java/controller/HomeController.java
@@ -79,7 +79,6 @@ public class HomeController {
 	@PostMapping("/home/savemsg")
 	@ResponseBody
 	public int saveMsg(int memberIdx, String content) {
-		System.out.println("controller: "+service.getChatMsgCnt());
 		if(service.getChatMsgCnt() >= 30) {
 			service.removeChatMsg();
 		}

--- a/KODI/src/main/java/dao/HomeDAO.java
+++ b/KODI/src/main/java/dao/HomeDAO.java
@@ -1,10 +1,12 @@
 package dao;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 
+import dto.HomeChatMsgDTO;
 import dto.VehicleDTO;
 
 @Repository("homedao")
@@ -16,4 +18,38 @@ public interface HomeDAO {
 	 * @return 교통수단 비용 리스트
 	 */
 	List<VehicleDTO> selectVehicleList();
+
+	/**
+	 * 메시지 개수 조회
+	 * @return 저장된 메시지 개수
+	 */
+	int searchChatMsgCnt();
+
+	/**
+	 * 가장 오래된 메시지 삭제
+	 * @return 삭제 성공 여부(1|0)
+	 */
+	int deleteChatMsg();
+
+	/**
+	 * 메시지 저장
+	 * @param memberIdx
+	 * @param content
+	 * @return 저장 성공 여부(1|0)
+	 */
+	int insertChatMsg(HashMap<String, Object> map);
+
+	/**
+	 * 모든 메시지 조회
+	 * @return 모든 메시지 리스트
+	 */
+	List<HomeChatMsgDTO> selectAllChatMsg();
+
+	/**
+	 * 메시지 작성자명 조회
+	 * @param memberIdx
+	 * @return 메시지 작성자명
+	 */
+	String selectMemberName(int memberIdx);
+
 }

--- a/KODI/src/main/java/dto/HomeAllChatDTO.java
+++ b/KODI/src/main/java/dto/HomeAllChatDTO.java
@@ -1,0 +1,15 @@
+package dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeAllChatDTO {
+	private HomeChatMsgDTO chatMsgDTO;
+	private String memberName;
+}

--- a/KODI/src/main/java/dto/HomeChatMsgDTO.java
+++ b/KODI/src/main/java/dto/HomeChatMsgDTO.java
@@ -1,0 +1,17 @@
+package dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeChatMsgDTO {
+	private int chatMsgIdx;
+	private String content;
+	private String regdate;
+	private int memberIdx;
+}

--- a/KODI/src/main/java/service/HomeService.java
+++ b/KODI/src/main/java/service/HomeService.java
@@ -1,5 +1,7 @@
 package service;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +9,10 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import dao.HomeDAO;
+import dto.AllChatDTO;
+import dto.ChatMsgDTO;
+import dto.HomeAllChatDTO;
+import dto.HomeChatMsgDTO;
 import dto.VehicleDTO;
 
 @Service("homeservice")
@@ -21,6 +27,54 @@ public class HomeService {
 	 */
 	public List<VehicleDTO> getVehicleList() {
 		return dao.selectVehicleList();
+	}
+
+	/**
+	 * 메시지 개수 조회
+	 * @return 저장된 메시지 개수
+	 */
+	public int getChatMsgCnt() {
+		return dao.searchChatMsgCnt();
+	}
+
+	/**
+	 * 가장 오래된 메시지 삭제
+	 */
+	public void removeChatMsg() {
+		dao.deleteChatMsg();
+	}
+
+	/**
+	 * 메시지 저장
+	 * @param memberIdx
+	 * @param content
+	 * @return 저장 성공 여부(1|0)
+	 */
+	public int saveChatMsg(int memberIdx, String content) {
+		HashMap<String, Object> map = new HashMap<>();
+		
+		map.put("memberIdx", memberIdx);
+		map.put("content", content);
+		
+		return dao.insertChatMsg(map);	
+	}
+
+	/**
+	 * 모든 메시지 조회
+	 * @return 모든 메시지 리스트
+	 */
+	public List<HomeAllChatDTO> selectAllChatMsg() {
+		List<HomeChatMsgDTO> chatMsgDTO = dao.selectAllChatMsg();
+		
+		List<HomeAllChatDTO> allChatDTO = new ArrayList<>();
+		
+		for (HomeChatMsgDTO dto : chatMsgDTO) {
+			String memberName = dao.selectMemberName(dto.getMemberIdx());
+			
+			allChatDTO.add(new HomeAllChatDTO(dto, memberName));
+		}
+
+		return allChatDTO;
 	}
 	
 }

--- a/KODI/src/main/resources/mybatis/mapper/Home-mapping.xml
+++ b/KODI/src/main/resources/mybatis/mapper/Home-mapping.xml
@@ -28,5 +28,22 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 		sejong_cost as sejongCost
 		from vehicle_cost
 	</select>
+	<select id="searchChatMsgCnt" resultType="int">
+		select count(*) from home_chat_msg
+	</select>
+	<select id="selectAllChatMsg" resultType="homechatmsgdto">
+		select chat_msg_idx as chatMsgIdx, content, regdate, member_idx as memberIdx from home_chat_msg
+	</select>
+	<select id="selectMemberName" resultType="String" parameterType="int">
+		select member_name as memberName from members where member_idx = #{memberIdx}
+	</select>
+	
+	<insert id="insertChatMsg" parameterType="hashmap">
+		insert into home_chat_msg(content, regdate, member_idx) values(#{content}, now(), #{memberIdx})
+	</insert>
+	
+	<delete id="deleteChatMsg">
+		delete from home_chat_msg order by regdate asc limit 1
+	</delete>
 </mapper>
 

--- a/KODI/src/main/resources/mybatis/mybatis-config.xml
+++ b/KODI/src/main/resources/mybatis/mybatis-config.xml
@@ -20,5 +20,6 @@
 		<typeAlias type="dto.PostLikeDTO" alias="postlikedto" />
 		<typeAlias type="dto.PostTagDTO" alias="posttagdto" />
 		<typeAlias type="dto.VehicleDTO" alias="vehicledto" />
+		<typeAlias type="dto.HomeChatMsgDTO" alias="homechatmsgdto" />
 	</typeAliases>
 </configuration>

--- a/KODI/src/main/resources/static/css/Home.css
+++ b/KODI/src/main/resources/static/css/Home.css
@@ -151,12 +151,16 @@ li {
 	
 }
 
-
-
-
-@media screen and (max-width:659px) {
+@media screen and (max-width:499px) {
 	#sendMsgInput {
-		width: 58%;
+		width: 54%;
+		margin-left: 10%;
+	}
+}
+
+@media screen and (min-width:500px) and (max-width:659px) {
+	#sendMsgInput {
+		width: 59%;
 		margin-left: 10%;
 	}
 }
@@ -168,14 +172,14 @@ li {
 	}
 }
 
-@media screen and (min-width:900px) and (max-width:1399px) {
+@media screen and (min-width:900px) and (max-width:1199px) {
 	#sendMsgInput {
-		width: 70%;
+		width: 68%;
 		margin-left: 10%;
 	}
 }
 
-@media screen and (min-width:1400px) {
+@media screen and (min-width:1200px) {
 	#sendMsgInput {
 		width: 71%;
 		margin-left: 10%;
@@ -203,7 +207,7 @@ li {
 	margin-left: 10%;
 	margin-right: 10%;
 	padding: 20px;
-	/*height: 500px;*/
+	height: 500px;
 	overflow-y: scroll;
 }
 

--- a/KODI/src/main/resources/static/css/Home.css
+++ b/KODI/src/main/resources/static/css/Home.css
@@ -203,6 +203,8 @@ li {
 	margin-left: 10%;
 	margin-right: 10%;
 	padding: 20px;
+	/*height: 500px;*/
+	overflow-y: scroll;
 }
 
 #friendName {

--- a/KODI/src/main/resources/static/css/Home.css
+++ b/KODI/src/main/resources/static/css/Home.css
@@ -221,15 +221,15 @@ li {
 
 #content {
 	display: inline-block;
-	margin-left: 20px;
+	margin-left: 10px;
 	border: 2px solid #EDF2F6;
 	border-radius: 10px;
 	background-color: #EDF2F6;
 	padding: 5px 20px;
+	text-align: center;
 }
 
 #regdate {
-	margin-left: 92px;
 	margin-top: 0px;
 	font-size: small;
 }

--- a/KODI/src/main/resources/static/css/LiveChat.css
+++ b/KODI/src/main/resources/static/css/LiveChat.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-@media screen and (max-width:659px) {
+@media screen and (max-width:549px) {
 	#exitChat {
 		margin-right: 10%;
 	}
@@ -9,7 +9,21 @@
 		margin-right: 10%;
 	}
 	#sendMsgInput {
-		width: 58%;
+		width: 55%;
+		margin-left: 10%;
+	}
+}
+
+@media screen and (min-width:550px) and (max-width:659px) {
+	#exitChat {
+		margin-right: 10%;
+	}
+	#allMsgList {
+		margin-left: 10%;
+		margin-right: 10%;
+	}
+	#sendMsgInput {
+		width: 59%;
 		margin-left: 10%;
 	}
 }
@@ -23,7 +37,7 @@
 		margin-right: 10%;
 	}
 	#sendMsgInput {
-		width: 66%;
+		width: 67%;
 		margin-left: 10%;
 	}
 }
@@ -37,7 +51,7 @@
 		margin-right: 10%;
 	}
 	#sendMsgInput {
-		width: 70%;
+		width: 71%;
 		margin-left: 10%;
 	}
 }
@@ -51,7 +65,7 @@
 		margin-right: 15%;
 	}
 	#sendMsgInput {
-		width: 61%;
+		width: 62%;
 		margin-left: 15%;
 	}
 }
@@ -65,7 +79,7 @@
 		margin-right: 20%;
 	}
 	#sendMsgInput {
-		width: 53%;
+		width: 54%;
 		margin-left: 20%;
 	}
 }
@@ -97,6 +111,8 @@
 	margin-top: 70px;
 	margin-bottom: 20px;
 	padding: 20px;
+	height: 500px;
+	overflow-y: scroll;
 }
 
 #friendName {
@@ -109,15 +125,15 @@
 
 #content {
 	display: inline-block;
-	margin-left: 20px;
+	margin-left: 10px;
 	border: 2px solid #EDF2F6;
 	border-radius: 10px;
 	background-color: #EDF2F6;
 	padding: 5px 20px;
+	text-align: center;
 }
 
 #regdate {
-	margin-left: 92px;
 	margin-top: 0px;
 	font-size: small;
 }
@@ -138,7 +154,7 @@
 #sendMsgBtn {
 	display: inline-block;
 	cursor: pointer;
-	border: 2px solid #EDF2F6;
+	border: 2px solid #EDF2F6;	
 	border-radius: 5px;
 	background-color: #EDF2F6;
 	width: 65px;

--- a/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
@@ -79,9 +79,7 @@
 			chatContent.setAttribute("style", "display: flex; font-size: small; margin: 15px;");
 			
 			json = JSON.parse('${one.content}');
-			
-			//alert(json.message.result.translatedText);
-			
+						
 			if(json.message.result.translatedText == "null"){
 				chatContent.innerHTML += "...";				
 			} else {

--- a/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ChatList.jsp
@@ -244,6 +244,58 @@
 		}	
 	};
 	
+	function enterKey(e){
+		if(e.keyCode == 13) {
+			if(sessionId == ${chatListInfo.memberIdx}){
+				if(searchInput.value == ""){
+					alert("검색할 친구를 입력해주세요");
+				} else {
+					var data = {memberIdx: sessionId, friendName: searchInput.value};
+					
+					$.ajax({
+						url: "/api/chatlist/search",
+						data: JSON.stringify(data),
+						type: "post",
+						contentType: "application/json",
+						dataType: "json",
+						success: function(response){
+							let friendList = document.getElementById("friendList");
+							
+							friendList.innerHTML = "";
+							
+							let oneFriend;
+							let chatBtn;
+							
+							for (var i = 0; i < response.length; i++) {
+								oneFriend = document.createElement("div");
+								oneFriend.setAttribute("id", response[i].friendMemberIdx);
+								oneFriend.setAttribute("style", "padding-top: 5px; padding-left: 5px; padding-right: 5px;");
+								oneFriend.innerHTML += response[i].friendMemberName;
+								
+								chatBtn = document.createElement("input");
+								chatBtn.setAttribute("type", "button");
+								chatBtn.setAttribute("id", "chatBtn");
+								chatBtn.setAttribute("value", "채팅");
+								chatBtn.setAttribute("style", "display: inline-block; border:none; border-radius: 5px; background-color:#EDF2F6; color:gray; width: 50px; float:right; cursor: pointer;");
+								chatBtn.setAttribute("onclick", `clickChatBtn(${"${response[i].friendMemberIdx}"})`);
+								
+								oneFriend.appendChild(chatBtn);
+								
+								oneFriend.innerHTML += "<hr>";
+								
+								friendList.appendChild(oneFriend);
+							}
+						},
+						error: function(request, e){
+							alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);
+						}
+					});
+				}
+			} else {
+				alert("친구 검색할 수 없습니다.");
+			}
+		};
+	};
 </script>
 
 <body>
@@ -257,7 +309,7 @@
 			<p id="title">친구 검색</p>
 
 			<div id="searchInputDiv">
-				<input id="searchInput" type="search" placeholder="친구 검색">
+				<input id="searchInput" type="search" placeholder="친구 검색" onkeypress="enterKey(event)">
 				<button id="searchBtn" type="button">
 					<img id="searchIcon" src="/image/icon/search.png" align="center">
 				</button>

--- a/KODI/src/main/webapp/WEB-INF/views/Home.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Home.jsp
@@ -111,6 +111,10 @@ function showData() {
 			oneMsg.innerHTML += "<br>";
 		};
 		
+		if(json.message.result.translatedText.length >= 90) {
+			oneMsg.innerHTML += "<br>";
+		};
+		
 		oneMsg.appendChild(regdate);
 
 		oneMsg.innerHTML += "<br><br>";
@@ -128,7 +132,7 @@ function webSocket(){
 
 	if(websocket == null){
 		websocket = new WebSocket("ws://localhost:7777/home");
-		//websocket = new WebSocket("ws://192.168.0.13:7777/home");
+		//websocket = new WebSocket("ws://192.168.0.13:7777/home"); // 추후 ncp 배포 공인 IP로 변경
 		
 		websocket.onopen = function(){console.log("웹소켓 연결성공");};
 		websocket.onclose = function(){console.log("웹소켓 해제성공");};
@@ -226,6 +230,10 @@ function webSocket(){
 								oneMsg.innerHTML += "<br>";
 							};
 							
+							if(json.message.result.translatedText.length >= 90) {
+								oneMsg.innerHTML += "<br>";
+							};
+							
 							oneMsg.appendChild(regdate);
 
 							oneMsg.innerHTML += "<br><br>";
@@ -255,21 +263,6 @@ function webSocket(){
 	$("#sendMsgBtn").on("click", function(){
 		sendMsg();
 	});
-	
-	/* function sendMsg() {
-		// 웹소켓 서버로 데이터 보내는 부분
-		let sendMsgInput = document.getElementById("sendMsgInput");
-
-		if(sendMsgInput.value == ""){
-			$("#sendMsgBtn").attr("disabled", false);
-		} else {
-			let sendData = [sendMsgInput.value, sessionId];
-			websocket.send(sendData);
-
-			sendMsgInput.value = "";
-			console.log("웹소켓 서버에게 송신성공");
-		};
-	}; */
 	
 	function sendMsg() {
 		// 웹소켓 서버로 데이터 보내는 부분

--- a/KODI/src/main/webapp/WEB-INF/views/Home.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Home.jsp
@@ -35,6 +35,8 @@ $(document).ready(function() {
 	});
 	
 	webSocket();
+	
+	//$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
 
 }); //ready
 

--- a/KODI/src/main/webapp/WEB-INF/views/Home.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Home.jsp
@@ -34,18 +34,101 @@ $(document).ready(function() {
 		window.location.href = "/api/diningcost";
 	});
 	
+	showData();
 	webSocket();
 	
-	//$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
+	$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
 
 }); //ready
+
+function showData() {
+	let allMsgList = document.getElementById("allMsgList");
+	
+	let oneMsg;
+	let friendName;
+	let content;
+	let regdate;
+	let json;
+	
+	<c:forEach items="${allChatMsg}" var="one">
+		oneMsg = document.createElement("div");
+		oneMsg.setAttribute("id", "${one.chatMsgDTO.chatMsgIdx}");
+		oneMsg.setAttribute("style", "display: inline;");
+		
+		friendName = document.createElement("p");
+		friendName.setAttribute("id", "friendName");
+		friendName.innerHTML = "${one.memberName}";
+		
+		content = document.createElement("p");
+		content.setAttribute("id", "content");
+		
+		json = JSON.parse('${one.chatMsgDTO.content}');
+		
+		content.innerHTML = json.message.result.translatedText;
+		
+		if(sessionId == "${one.chatMsgDTO.memberIdx}"){
+			friendName.setAttribute("style", "float: right;");
+			
+			if(json.message.result.translatedText.length < 35) {
+				content.setAttribute("style", "border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");					
+			} else {
+				content.setAttribute("style", "text-align: left; width: 350px; word-break: break-all; border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");
+			}
+		} else {
+			friendName.setAttribute("style", "float: left;");
+			
+			if(json.message.result.translatedText.length < 35) {
+				content.setAttribute("style", "float: left;");
+			} else {
+				content.setAttribute("style", "text-align: left; width: 350px; float: left;");
+			}
+		}
+		
+		regdate = document.createElement("p");
+		regdate.setAttribute("id", "regdate");
+		regdate.innerHTML = "${one.chatMsgDTO.regdate}";
+		
+		if(sessionId == "${one.chatMsgDTO.memberIdx}"){
+			regdate.setAttribute("style", "margin-right: 70px; float: right;");
+		} else {
+			regdate.setAttribute("style", "margin-left: 80px; float: left;");
+		}
+		
+		oneMsg.appendChild(friendName);
+		oneMsg.appendChild(content);
+
+		oneMsg.innerHTML += "<br><br><br><br>";
+		
+		if(json.message.result.translatedText.length >= 35) {
+			oneMsg.innerHTML += "<br>";
+		};
+		
+		if(json.message.result.translatedText.length >= 50) {
+			oneMsg.innerHTML += "<br>";
+		};
+		
+		if(json.message.result.translatedText.length >= 70) {
+			oneMsg.innerHTML += "<br>";
+		};
+		
+		oneMsg.appendChild(regdate);
+
+		oneMsg.innerHTML += "<br><br>";
+		
+		allMsgList.appendChild(oneMsg);
+	</c:forEach>
+	
+	$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
+};
+
+
 
 function webSocket(){
 	websocket = null;
 
 	if(websocket == null){
-		//websocket = new WebSocket("ws://localhost:7777/home");
-		websocket = new WebSocket("ws://192.168.0.13:7777/home");
+		websocket = new WebSocket("ws://localhost:7777/home");
+		//websocket = new WebSocket("ws://192.168.0.13:7777/home");
 		
 		websocket.onopen = function(){console.log("웹소켓 연결성공");};
 		websocket.onclose = function(){console.log("웹소켓 해제성공");};
@@ -79,28 +162,82 @@ function webSocket(){
 				data: {"memberIdx": sendInfo[1]},
 				type: "post",
 				dataType: "text",
-				success: function(response){
-					oneMsg = document.createElement("div");
-					
-					friendName = document.createElement("p");
-					friendName.setAttribute("id", "friendName");
-					friendName.innerHTML = response;
-					
-					content = document.createElement("p");
-					content.setAttribute("id", "content");
-					content.innerHTML = sendInfo[0];
+				success: function(membername){
+					$.ajax({
+						url: "/api/chatroom/translatemsg",
+						data: {"sendMemberIdx": sendInfo[1] ,"msg": sendInfo[0]},
+						type: "post",
+						dataType: "text",
+						success: function(translatemsg){
+							let json = JSON.parse(translatemsg);
+							
+							oneMsg = document.createElement("div");
+							
+							friendName = document.createElement("p");
+							friendName.setAttribute("id", "friendName");
+							friendName.innerHTML = membername;
+							
+							content = document.createElement("p");
+							content.setAttribute("id", "content");
+							content.innerHTML = json.message.result.translatedText;
+							
+							if(sessionId == sendInfo[1]){
+								friendName.setAttribute("style", "float: right;");
+								
+								if(json.message.result.translatedText.length < 35) {
+									content.setAttribute("style", "border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");					
+								} else {
+									content.setAttribute("style", "text-align: left; width: 350px; word-break: break-all; border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");
+								}
+							} else {
+								friendName.setAttribute("style", "float: left;");
+								
+								if(json.message.result.translatedText.length < 35) {
+									content.setAttribute("style", "float: left;");
+								} else {
+									content.setAttribute("style", "text-align: left; width: 350px; float: left;");
+								}
+							}
 
-					regdate = document.createElement("p");
-					regdate.setAttribute("id", "regdate");
-					regdate.innerHTML = dateString + " " + timeString;
-					
-					oneMsg.appendChild(friendName);
-					oneMsg.appendChild(content);
-					oneMsg.appendChild(regdate);
+							regdate = document.createElement("p");
+							regdate.setAttribute("id", "regdate");
+							regdate.innerHTML = dateString + " " + timeString;
+							
+							if(sessionId == sendInfo[1]){
+								regdate.setAttribute("style", "margin-right: 70px; float: right;");
+							} else {
+								regdate.setAttribute("style", "margin-left: 80px; float: left;");
+							}
+							
+							oneMsg.appendChild(friendName);
+							oneMsg.appendChild(content);
 
-					oneMsg.innerHTML += "<hr>";
-					
-					allMsgList.appendChild(oneMsg);
+							oneMsg.innerHTML += "<br><br><br><br>";
+							
+							if(json.message.result.translatedText.length >= 35) {
+								oneMsg.innerHTML += "<br>";
+							};
+							
+							if(json.message.result.translatedText.length >= 50) {
+								oneMsg.innerHTML += "<br>";
+							};
+							
+							if(json.message.result.translatedText.length >= 70) {
+								oneMsg.innerHTML += "<br>";
+							};
+							
+							oneMsg.appendChild(regdate);
+
+							oneMsg.innerHTML += "<br><br>";
+							
+							allMsgList.appendChild(oneMsg);
+							
+							$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
+						},
+						error: function(request, e){
+							alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);
+						}
+					});
 				},
 				error: function(request, e){
 					alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);
@@ -109,7 +246,17 @@ function webSocket(){
 		};
 	};
 	
+	$("#sendMsgInput").on("keypress", function(e){
+		if(e.keyCode == 13) {
+			sendMsg();				
+		};
+	});
+	
 	$("#sendMsgBtn").on("click", function(){
+		sendMsg();
+	});
+	
+	/* function sendMsg() {
 		// 웹소켓 서버로 데이터 보내는 부분
 		let sendMsgInput = document.getElementById("sendMsgInput");
 
@@ -122,7 +269,33 @@ function webSocket(){
 			sendMsgInput.value = "";
 			console.log("웹소켓 서버에게 송신성공");
 		};
-	});
+	}; */
+	
+	function sendMsg() {
+		// 웹소켓 서버로 데이터 보내는 부분
+		let sendMsgInput = document.getElementById("sendMsgInput");
+
+		if(sendMsgInput.value == ""){
+			$("#sendMsgBtn").attr("disabled", false);
+		} else {
+			let sendData = [sendMsgInput.value, sessionId];
+			websocket.send(sendData);
+			
+			$.ajax({
+				url: "/api/home/savemsg",
+				data: {"memberIdx": sessionId, "content": sendMsgInput.value},
+				type: "post",
+				success: function(response){
+					sendMsgInput.value = "";
+					console.log("메시지 DB 저장 성공");
+				},
+				error: function(request, e){
+					alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);
+				}
+			});
+			console.log("웹소켓 서버에게 송신성공");
+		};
+	};
 };
 </script>
 

--- a/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
@@ -114,6 +114,10 @@
 				oneMsg.innerHTML += "<br>";
 			};
 			
+			if(json.message.result.translatedText.length >= 90) {
+				oneMsg.innerHTML += "<br>";
+			};
+			
 			oneMsg.appendChild(regdate);
 
 			oneMsg.innerHTML += "<br><br>";
@@ -129,7 +133,7 @@
 		
 		if(websocket == null){
 			websocket = new WebSocket("ws://localhost:7777/chatroom");
-			//websocket = new WebSocket("ws://192.168.0.13:7777/chatroom");
+			//websocket = new WebSocket("ws://192.168.0.13:7777/chatroom"); // 추후 ncp 배포 공인 IP로 변경
 			
 			websocket.onopen = function() {
 				console.log("웹소켓 연결성공");
@@ -227,6 +231,10 @@
 								};
 								
 								if(json.message.result.translatedText.length >= 70) {
+									oneMsg.innerHTML += "<br>";
+								};
+								
+								if(json.message.result.translatedText.length >= 90) {
 									oneMsg.innerHTML += "<br>";
 								};
 								

--- a/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/LiveChat.jsp
@@ -33,7 +33,7 @@
 				if(response == 1){
 					showData();
 					webSocket();
-				} else {
+			} else {
 					alert("해당 채팅방에 입장할 수 없습니다.");
 					location.href = "/api/chatlist/" + sessionId;
 				}
@@ -56,6 +56,7 @@
 		<c:forEach items="${allChatMsg}" var="one">
 			oneMsg = document.createElement("div");
 			oneMsg.setAttribute("id", "${one.chatMsgDTO.chatMsgIdx}");
+			oneMsg.setAttribute("style", "display: inline;");
 			
 			friendName = document.createElement("p");
 			friendName.setAttribute("id", "friendName");
@@ -68,28 +69,69 @@
 			
 			content.innerHTML = json.message.result.translatedText;
 			
+			if(sessionId == "${one.chatMsgDTO.memberIdx}"){
+				friendName.setAttribute("style", "float: right;");
+				
+				if(json.message.result.translatedText.length < 35) {
+					content.setAttribute("style", "border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");					
+				} else {
+					content.setAttribute("style", "text-align: left; width: 350px; word-break: break-all; border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");
+				}
+			} else {
+				friendName.setAttribute("style", "float: left;");
+				
+				if(json.message.result.translatedText.length < 35) {
+					content.setAttribute("style", "float: left;");
+				} else {
+					content.setAttribute("style", "text-align: left; width: 350px; float: left;");
+				}
+			}
+			
 			regdate = document.createElement("p");
 			regdate.setAttribute("id", "regdate");
 			regdate.innerHTML = "${one.chatMsgDTO.regdate}";
 			
+			if(sessionId == "${one.chatMsgDTO.memberIdx}"){
+				regdate.setAttribute("style", "margin-right: 70px; float: right;");
+			} else {
+				regdate.setAttribute("style", "margin-left: 80px; float: left;");
+			}
+			
 			oneMsg.appendChild(friendName);
 			oneMsg.appendChild(content);
+
+			oneMsg.innerHTML += "<br><br><br><br>";
+			
+			if(json.message.result.translatedText.length >= 35) {
+				oneMsg.innerHTML += "<br>";
+			};
+			
+			if(json.message.result.translatedText.length >= 50) {
+				oneMsg.innerHTML += "<br>";
+			};
+			
+			if(json.message.result.translatedText.length >= 70) {
+				oneMsg.innerHTML += "<br>";
+			};
+			
 			oneMsg.appendChild(regdate);
 
-			oneMsg.innerHTML += "<hr>";
+			oneMsg.innerHTML += "<br><br>";
 			
 			allMsgList.appendChild(oneMsg);
 		</c:forEach>
-	};
 		
+		$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
+	};
+
 	function webSocket(){
 		let websocket = null;
 		
 		if(websocket == null){
-			//websocket = new WebSocket("ws://localhost:7777/chatroom");
-			websocket = new WebSocket("ws://192.168.0.13:7777/chatroom");
+			websocket = new WebSocket("ws://localhost:7777/chatroom");
+			//websocket = new WebSocket("ws://192.168.0.13:7777/chatroom");
 			
-			websocket.onopen = function(){
+			websocket.onopen = function() {
 				console.log("웹소켓 연결성공");
 				websocket.send(${chatIdx});
 			};
@@ -142,18 +184,59 @@
 								content = document.createElement("p");
 								content.setAttribute("id", "content");
 								content.innerHTML = json.message.result.translatedText;
+								
+								if(sessionId == sendInfo[1]){
+									friendName.setAttribute("style", "float: right;");
+									
+									if(json.message.result.translatedText.length < 35) {
+										content.setAttribute("style", "border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");					
+									} else {
+										content.setAttribute("style", "text-align: left; width: 350px; word-break: break-all; border: 2px solid #F8E8EE; background-color: #F8E8EE; float: right;");
+									}
+								} else {
+									friendName.setAttribute("style", "float: left;");
+									
+									if(json.message.result.translatedText.length < 35) {
+										content.setAttribute("style", "float: left;");
+									} else {
+										content.setAttribute("style", "text-align: left; width: 350px; float: left;");
+									}
+								}
 
 								regdate = document.createElement("p");
 								regdate.setAttribute("id", "regdate");
 								regdate.innerHTML = dateString + " " + timeString;
 								
+								if(sessionId == sendInfo[1]){
+									regdate.setAttribute("style", "margin-right: 70px; float: right;");
+								} else {
+									regdate.setAttribute("style", "margin-left: 80px; float: left;");
+								}
+								
 								oneMsg.appendChild(friendName);
 								oneMsg.appendChild(content);
+
+								oneMsg.innerHTML += "<br><br><br><br>";
+								
+								if(json.message.result.translatedText.length >= 35) {
+									oneMsg.innerHTML += "<br>";
+								};
+								
+								if(json.message.result.translatedText.length >= 50) {
+									oneMsg.innerHTML += "<br>";
+								};
+								
+								if(json.message.result.translatedText.length >= 70) {
+									oneMsg.innerHTML += "<br>";
+								};
+								
 								oneMsg.appendChild(regdate);
 
-								oneMsg.innerHTML += "<hr>";
+								oneMsg.innerHTML += "<br><br>";
 								
 								allMsgList.appendChild(oneMsg);
+								
+								$('#allMsgList').scrollTop($('#allMsgList')[0].scrollHeight);
 							},
 							error: function(request, e){
 								alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);
@@ -167,7 +250,23 @@
 			};
 		};
 		
+		$("#sendMsgInput").on("keypress", function(e){
+			if(e.keyCode == 13) {
+				sendMsg();				
+			};
+		});
+		
 		$("#sendMsgBtn").on("click", function(){
+			sendMsg();
+		});
+		
+		$("#exitChat").on("click", function(){
+			websocket.send(${chatIdx});
+			websocket.close();
+			location.href = "/api/chatlist/" + sessionId;
+		});
+		
+		function sendMsg() {
 			// 웹소켓 서버로 데이터 보내는 부분
 			let sendMsgInput = document.getElementById("sendMsgInput");
 
@@ -194,14 +293,8 @@
 					}
 				});
 				console.log("웹소켓 서버에게 송신성공");
-			};			
-		});
-		
-		$("#exitChat").on("click", function(){
-			websocket.send(${chatIdx});
-			websocket.close();
-			location.href = "/api/chatlist/" + sessionId;
-		});
+			};
+		};
 	};
 </script>
 
@@ -212,7 +305,7 @@
 
 	<button id="exitChat" type="button">
 		<img id="exitIcon" src="/image/icon/exit-chat.png" align="center">
-		<p id="exitMsg">채팅방 나가기</p>
+		<p id="exitMsg">뒤로 가기</p>
 	</button>
 
 	<div id="allMsgList"></div>


### PR DESCRIPTION
- 공통
  - enter 클릭 시 메시지 전송
  - 카톡처럼 채팅 내용 CSS 변경
  - 채팅방 스크롤 추가, 가장 최근 메시지로 자동 스크롤 이동
- 홈페이지
  - 기존
    - 새로고침하면 실시간 채팅방 메시지 리셋
  - 수정
    - 실시간 채팅방의 최근 메시지 30개만 DB에 저장 후 불러오기
    - 30개 넘으면 가장 오래된 메시지 삭제 및 가장 최근 메시지 추가