### PR TITLE
[UPDATE] 지도 페이지, 상세 게시글 이전 페이지 경로 설정, 수정 페이지 컨트롤러 작성 완료시 페이지 이동

### DIFF
--- a/KODI/src/main/java/controller/MapController.java
+++ b/KODI/src/main/java/controller/MapController.java
@@ -41,7 +41,6 @@ public class MapController {
 	@PostMapping("/map/marking")
 	@ResponseBody
 	public List<String> selectMarking(@RequestParam("marking") String marking, HttpSession session) {
-		System.out.println(marking);
 		//세션 받아서 int 타입으로 변환
 		String sessionIdx = (String)session.getAttribute("memberIdx");
 		Integer myMemberIdx = Integer.parseInt(sessionIdx);
@@ -81,8 +80,6 @@ public class MapController {
 				markList.add(address);
 			}
 		}
-		
-		System.out.println(markList.toString());
 		
 		return markList;
 	}

--- a/KODI/src/main/java/controller/ModifyPostController.java
+++ b/KODI/src/main/java/controller/ModifyPostController.java
@@ -90,15 +90,16 @@ public class ModifyPostController {
 		}
 		modifyservice.updatePost(writePostDTO, fileName, myMemberIdx);
 		
-		String referer = request.getHeader("Referer");
+		//상세 게시글로 돌아가기 위한 게시글 idx
+		int postIdx = writePostDTO.getPostIdx();
 		
-		return "redirect:" + referer;
+		return "redirect:/api/post/" + postIdx;
 	}
 	
 	//현재 DB에 있는 이미지 삭제
 	@PostMapping("/post/image/isdelete")
 	public void isDeleteImage(
-			@RequestParam("imageSrc") String imageSrc, 
+			@RequestParam("imageSrc") String imageSrc,
 			@RequestParam("postIdx") int postIdx) {
 		
 		modifyservice.deleteImageSrc(postIdx, imageSrc);

--- a/KODI/src/main/java/service/MapService.java
+++ b/KODI/src/main/java/service/MapService.java
@@ -37,10 +37,10 @@ public class MapService {
 		List<Integer> realFriend = new ArrayList<Integer>();
 		
 		for(Integer idx : friendIdxs) {
-			//member_idx가 친구의 idx인 것들의 is_friend의 값
+			//member_idx가 친구의 idx이면서 friend_member_idx가 나의 idx인 것들의 is_friend의 값
 			boolean isFriend = dao.selectIsFriend(idx, myMemberIdx);
 			//isFriend가 true(1)인 경우
-			if(isFriend = true) {
+			if(isFriend == true) {
 				//서로 친구인 친구의 member_idx값을 저장
 				realFriend.add(idx);
 			}

--- a/KODI/src/main/webapp/WEB-INF/views/Map.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/Map.jsp
@@ -71,7 +71,7 @@ function initMap(addresses, zoomLevel) {
                         content: 
                         `
                         <div style="font-family: 'NanumSquareNeo';  ">
-                        ` + address + `
+                        ` + address + ` <br><br>
                         <a href="https://google.com/maps/place/` + address + `" target="_blank">구글 지도에서 보기</a>
                         `
                     });

--- a/KODI/src/main/webapp/WEB-INF/views/ReadPostOne.jsp
+++ b/KODI/src/main/webapp/WEB-INF/views/ReadPostOne.jsp
@@ -338,7 +338,13 @@
 						contentType: "application/json",
 						success: function(response){
 							alert("게시물을 삭제하였습니다.");
-							location.href = "/api/post";
+							var referrer = document.referrer;
+							if(referrer == "http://localhost:7777/api/mypage"){
+								location.href = "/api/mypage";
+							}
+							else {
+								location.href = "/api/posts/food";
+							}
 						},
 						error: function(request, e){
 							alert("코드: " + request.status + "메시지: " + request.responseText + "오류: " + e);


### PR DESCRIPTION
지도 페이지
- 구글 지도에서 보기 아래줄로 내리기 수정
- 서로 친구인 사이만 마커 표시되도록 수정

수정 페이지
- 작성 완료 버튼 클릭시 페이지 이동

상세 게시글 페이지
- 이전 페이지로 돌아가는 경로 2가지로 수정(전체 게시글에서 들어간 경우, 마이 페이지에서 들어간 경우)